### PR TITLE
Fix: cannot find derive macro Topic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vehicle-signals = "0.2"
+vehicle-signals = "0.2.1"
 cyclonedds-rs = "0.4.1"
 rand = "0.8.4"


### PR DESCRIPTION
Signed-off-by: Fanjun Kong <fanjun.kong@linux.dev>

This patch fix error below:

   Compiling futures v0.3.21
   Compiling cyclonedds-sys v0.1.6
   Compiling cyclonedds-rs v0.4.7
error: cannot find derive macro `Topic` in this scope
 --> /home/kong/src/coding/rust/github/demo-vehicle-speed-subscriber/target/debug/build/vehicle-signals-4cf4d462c203a86f/out/bindings.rs:6:47
  |
6 |     #[derive(Default, Deserialize, Serialize, Topic)]
  |                                               ^^^^^

Thanks